### PR TITLE
Add Factory macro

### DIFF
--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Factory.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Factory.scala
@@ -1,0 +1,163 @@
+package net.exoego.scalajs.types.util
+
+import scala.annotation.StaticAnnotation
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+import scala.scalajs.js
+
+/**
+  * Generate a case-class-like companion object with factory method, or add such method to the existing companion object.
+  * This might be helpful if you want to instantiate JS traits, especially it is a native (since a Scala.js-defined
+  * JS class cannot directly extend it).
+  *
+  * If the below code given,
+  *
+  * {{{
+  * @Factory
+  * trait Base extends js.Object {
+  *   var foo: String
+  *   val bar: js.UndefOr[js.Array[Int]]
+  *   def buz(x: String): Boolean
+  * }
+  * }}}
+  *
+  * it is identical to
+  *
+  * {{{
+  * trait Base extends js.Object {
+  *   var foo: String
+  *   val bar: js.UndefOr[js.Array[Int]]
+  *   def buz(x: String): Boolean
+  * }
+  *
+  * object Base {
+  *   def apply(
+  *     foo: String,
+  *     bar: js.UndefOr[js.Array[Int]] = js.undefined,
+  *   ): Base = ...
+  * }
+  * }}}
+  *
+  * so you can use factory methods like
+  *
+  * {{{
+  * val o1 = Existing(name = "yay")
+  *
+  * // instead of...
+  * val o2 = new Existing() {
+  *   override var name = "omg"
+  * }
+  * }}}
+  *
+  *
+  */
+class Factory extends StaticAnnotation {
+  def macroTransform(annottees: Any*): Any = macro Factory.impl
+}
+
+object Factory {
+  def impl(c: blackbox.Context)(annottees: c.Expr[Any]*) = {
+    import c.universe._
+    import Helper._
+    implicit val context: blackbox.Context = c
+
+    annotteeShouldBeTrait(c)(annottees)
+
+    def addFactoryMethod(cd: ClassDef, md: ModuleDef, isJsNative: Boolean): ModuleDef = {
+      if (md.impl.exists(_.isInstanceOf[TypeDef])) {
+        warning("Can't add factory method to companion object with type alias. This is known limitation.")
+        return md
+      }
+      val members: Seq[(Boolean, Symbol)] =
+        (c.typecheck(q"${cd}").symbol.asClass.toType.members.toSet -- c.typeOf[js.Object].members.toSet).toList
+          .filterNot(_.isConstructor)
+          .map(s => {
+            val isDefined = !(s.typeSignature.finalResultType <:< c.typeOf[js.UndefOr[_]])
+            (isDefined, s)
+          })
+          .filterNot {
+            case (_, s) =>
+              // TODO: Do not rely on string rep since toString is slow
+              val rep = s.toString
+              rep.startsWith("method ") || rep.startsWith("variable ") && s.asMethod.returnType == c.typeOf[Unit]
+          }
+          .sortBy(p => (!p._1, p._2.name.toString))
+      val impl = {
+        val groupedByDefined = members.groupBy(_._1)
+        val requiredArgs: Seq[c.universe.Apply] = groupedByDefined.getOrElse(true, Seq.empty).map {
+          case (_, s) =>
+            val memberName = s.name.toTermName
+            q"${memberName.toString} -> $memberName.asInstanceOf[scala.scalajs.js.Any]".asInstanceOf[Apply]
+        }
+        val optionalArgs = groupedByDefined.getOrElse(false, Seq.empty).map {
+          case (_, s) =>
+            val memberName = s.name.toTermName
+            q"$memberName.foreach(v$$ => obj$$.updateDynamic(${memberName.toString})(v$$.asInstanceOf[js.Any])) "
+              .asInstanceOf[Apply]
+        }
+        q"""
+           val obj$$ = scala.scalajs.js.Dynamic.literal(
+             ..$requiredArgs
+           )
+           ..$optionalArgs
+           obj$$.asInstanceOf[${md.name.toTypeName}]
+         """
+      }
+      val arguments = members
+        .map {
+          case (isDefined, s) =>
+            val name      = TermName(s.name.decodedName.toString)
+            val stringRep = s.toString
+            if (!stringRep.startsWith("value ") && !stringRep.startsWith("variable ")) {
+              EmptyTree
+            } else {
+              val returnType = s.asMethod.returnType
+              if (isDefined) {
+                q"${name}: ${returnType}"
+              } else {
+                ValDef(Modifiers(), name, q"${returnType}", q"scala.scalajs.js.undefined")
+              }
+            }
+        }
+        .filter(_.nonEmpty)
+      ModuleDef(
+        md.mods,
+        md.name,
+        Template(
+          md.impl.parents,
+          noSelfType,
+          md.impl.body ++ List(
+            q"""
+            def apply(
+              ..$arguments
+            ): ${md.name.toTypeName} = { ..$impl }
+            """
+          )
+        )
+      )
+    }
+    val inputs: List[Tree] = annottees.map(_.tree).toList
+    val outputs: List[Tree] = inputs match {
+      case (cd @ ClassDef(classMod, cName, _, _)) :: tail =>
+        val moduleDef: ModuleDef = tail match {
+          case (existingCompanionObject @ ModuleDef(_, mName, _)) :: Nil if cName.toTermName == mName =>
+            existingCompanionObject
+          case Nil =>
+            var moduleModFlags = NoFlags
+            if (classMod.hasFlag(Flag.PRIVATE)) moduleModFlags |= Flag.PRIVATE
+            if (classMod.hasFlag(Flag.PROTECTED)) moduleModFlags |= Flag.PROTECTED
+            if (classMod.hasFlag(Flag.LOCAL)) moduleModFlags |= Flag.LOCAL
+            val moduleMod  = Modifiers(moduleModFlags, classMod.privateWithin, Nil)
+            val moduleName = cName.toTermName
+            q"$moduleMod object $moduleName".asInstanceOf[ModuleDef]
+          case _ => bail("Expected a companion object")
+        }
+
+        val isJsNative = isScalaJsNative(c)(classMod)
+        cd :: addFactoryMethod(cd, moduleDef, isJsNative) :: Nil
+      case _ => bail("Must annotate a trait")
+    }
+
+    c.Expr[Any](Block(outputs, Literal(Constant(()))))
+  }
+}

--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Helper.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Helper.scala
@@ -4,14 +4,20 @@ import scala.reflect.macros.blackbox
 import scala.scalajs.js
 
 private[util] object Helper {
+  private final val libraryNamePrefix: String = "[scalajs-types-util]"
+  def warning(message: String)(implicit c: blackbox.Context): Unit = {
+    c.warning(c.enclosingPosition, s"${libraryNamePrefix} ${message}")
+  }
   def bail(message: String)(implicit c: blackbox.Context): Nothing = {
-    c.abort(c.enclosingPosition, message)
+    c.abort(c.enclosingPosition, s"${libraryNamePrefix} ${message}")
   }
 
   def annotteeShouldBeTrait(c: blackbox.Context)(annottees: Seq[c.Expr[Any]]): Unit = {
     import c.universe._
     annottees match {
       case List(Expr(ClassDef(mods, _, _, _))) if mods.hasFlag(Flag.TRAIT) =>
+      case List(Expr(ClassDef(mods, className, _, _)), Expr(ModuleDef(_, moduleName, _)))
+          if mods.hasFlag(Flag.TRAIT) && className.toTermName == moduleName =>
       case _ =>
         bail(s"Can annotate only trait")(c)
     }

--- a/macros/src/test/scala/net/exoego/scalajs/types/util/FactoryTest.scala
+++ b/macros/src/test/scala/net/exoego/scalajs/types/util/FactoryTest.scala
@@ -1,0 +1,101 @@
+package net.exoego.scalajs.types.util
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.scalajs.js
+
+class FactoryTest extends AnyFlatSpec with Matchers {
+  "Factory macro" should "not compile when NOT applied to a trait" in {
+    """@Factory def x: String = "a"""" shouldNot compile
+    """@Factory var x: String = "a"""" shouldNot compile
+    """@Factory val x: String = "a"""" shouldNot compile
+    """@Factory class X""" shouldNot compile
+    """@Factory object X""" shouldNot compile
+    """def x(@Factory y: X): String = "a"""" shouldNot compile
+  }
+
+  it should "compile when applied to a Scala.js-native trait" in {
+    """@Factory @js.native trait X""" should compile
+    """@Factory @js.native trait X {}""" should compile
+  }
+
+  it should "also compile when applied to a Scala-native trait" in {
+    """@Factory trait X""" should compile
+    """@Factory trait X {}""" should compile
+  }
+
+  "factory method " should "have defined parameter" in {
+    """ val a: Target = Target(name = "yay")
+      | """.stripMargin should compile
+    """ val a: Target = Target()
+      | """.stripMargin shouldNot compile
+
+    """ val a: TargetScalaNative = TargetScalaNative(name = "yay")
+      | """.stripMargin should compile
+    """ val a: TargetScalaNative = TargetScalaNative()
+      | """.stripMargin shouldNot compile
+  }
+
+  it should "allow omitting optional parameters" in {
+    """ val a: Target = Target(name = "yay")
+      | """.stripMargin should compile
+  }
+
+  it should "have parameters for variable and value members" in {
+    """ val a: Target = Target(name = "yay", age = 1, hoge = true)
+      | """.stripMargin should compile
+  }
+
+  it should "not not have parameter for def" in {
+    """ val a: Target = Target(name = "yay", foo = "FAIL")
+      | """.stripMargin shouldNot compile
+  }
+
+  it should "be added to the existing companion object" in {
+    """ val a: Existing = Existing(name = "yay")
+        | """.stripMargin should compile
+  }
+
+  it should "be added to the companion object with nested member" ignore {
+    """ val a: Nested = Nested(name = "yay")
+      | """.stripMargin should compile
+  }
+}
+
+@Factory
+@js.native
+trait Target extends js.Object {
+  val hoge: js.UndefOr[Boolean] = js.native
+  var age: js.UndefOr[Int]      = js.native
+  var name: String              = js.native
+
+  def foo: String = js.native
+}
+
+@Factory
+trait TargetScalaNative extends js.Object {
+  val hoge: js.UndefOr[Boolean]
+  var age: js.UndefOr[Int]
+  var name: String
+
+  def foo: String
+}
+
+@Factory
+@js.native
+trait Existing extends js.Object {
+  var name: String = js.native
+}
+object Existing {
+  val Z = "yay"
+}
+
+@Factory
+@js.native
+trait Nested extends js.Object {
+  var name: Nested.Z = js.native
+}
+object Nested {
+  type Z = String
+}


### PR DESCRIPTION
Closes #24 

Generate a case-class-like companion object with factory method, or add such method to the existing companion object.
This might be helpful if you want to instantiate JS traits, especially it is a native (since a Scala.js-defined  JS class cannot directly extend it).

If the below code given,

```scala
@Factory
trait Base extends js.Object {
    var foo: String
    val bar: js.UndefOr[js.Array[Int]]
    def buz(x: String): Boolean
}
```

it is identical to

```scala
trait Base extends js.Object {
    var foo: String
    val bar: js.UndefOr[js.Array[Int]]
    def buz(x: String): Boolean
}
object Base {
    def apply(
      foo: String,
      bar: js.UndefOr[js.Array[Int]] = js.undefined,
    ): Base = ...
}
```

so you can use factory methods like

```scala
val o1 = Existing(name = "yay")

// instead of...
val o2 = new Existing() {
    override var name = "omg"
}
```