### PR TITLE
Use compileTimeOnly since users may forget enabling macro

### DIFF
--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Factory.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Factory.scala
@@ -1,6 +1,6 @@
 package net.exoego.scalajs.types.util
 
-import scala.annotation.StaticAnnotation
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 import scala.scalajs.js
@@ -51,6 +51,7 @@ import scala.scalajs.js
   *
   *
   */
+@compileTimeOnly("Enable macro to expand this macro annotation")
 class Factory extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro Factory.impl
 }

--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Omit.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Omit.scala
@@ -1,6 +1,6 @@
 package net.exoego.scalajs.types.util
 
-import scala.annotation.StaticAnnotation
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 import scala.scalajs.js
@@ -40,6 +40,7 @@ import scala.scalajs.js
   *
   * @tparam T
   */
+@compileTimeOnly("Enable macro to expand this macro annotation")
 class Omit[T <: js.Object](keys: String*) extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro Omit.impl
 }

--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Partial.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Partial.scala
@@ -1,6 +1,6 @@
 package net.exoego.scalajs.types.util
 
-import scala.annotation.StaticAnnotation
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 import scala.scalajs.js
@@ -42,6 +42,7 @@ import scala.scalajs.js
   *
   * @tparam T
   */
+@compileTimeOnly("Enable macro to expand this macro annotation")
 class Partial[T <: js.Object] extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro Partial.impl
 }

--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Pick.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Pick.scala
@@ -1,6 +1,6 @@
 package net.exoego.scalajs.types.util
 
-import scala.annotation.StaticAnnotation
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 import scala.scalajs.js
@@ -40,6 +40,7 @@ import scala.scalajs.js
   *
   * @tparam T
   */
+@compileTimeOnly("Enable macro to expand this macro annotation")
 class Pick[T <: js.Object](keys: String*) extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro Pick.impl
 }

--- a/macros/src/main/scala/net/exoego/scalajs/types/util/ReadOnly.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/ReadOnly.scala
@@ -1,6 +1,6 @@
 package net.exoego.scalajs.types.util
 
-import scala.annotation.StaticAnnotation
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 import scala.scalajs.js
@@ -45,6 +45,7 @@ import scala.scalajs.js
   *
   * @tparam T
   */
+@compileTimeOnly("Enable macro to expand this macro annotation")
 class ReadOnly[T <: js.Object] extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro ReadOnly.impl
 }

--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Record.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Record.scala
@@ -1,6 +1,6 @@
 package net.exoego.scalajs.types.util
 
-import scala.annotation.StaticAnnotation
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 import scala.scalajs.js
@@ -38,6 +38,7 @@ import scala.scalajs.js
   *
   * @tparam T
   */
+@compileTimeOnly("Enable macro to expand this macro annotation")
 class Record[T <: js.Object](keys: String*) extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro Record.impl
 }

--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Required.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Required.scala
@@ -1,6 +1,6 @@
 package net.exoego.scalajs.types.util
 
-import scala.annotation.StaticAnnotation
+import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 import scala.scalajs.js
@@ -45,6 +45,7 @@ import scala.scalajs.js.UndefOr
   *
   * @tparam T
   */
+@compileTimeOnly("Enable macro to expand this macro annotation")
 class Required[T <: js.Object] extends StaticAnnotation {
   def macroTransform(annottees: Any*): Any = macro Required.impl
 }


### PR DESCRIPTION
Closes #48 

It is recommended for macro annotations:

> https://docs.scala-lang.org/overviews/macros/annotations.html
> It is not mandatory, but is recommended to avoid confusion. Macro annotations look like normal annotations to the vanilla Scala compiler, so if you forget to enable the macro paradise plugin in your build, your annotations will silently fail to expand. 