### PR TITLE
Generic types support in Factory macro

### DIFF
--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Factory.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Factory.scala
@@ -65,7 +65,7 @@ object Factory {
     annotteeShouldBeTrait(c)(annottees)
 
     def addFactoryMethod(rawCd: ClassDef, md: ModuleDef, isJsNative: Boolean): ModuleDef = {
-      val cd = if (!md.impl.exists(_.isInstanceOf[TypeDef])) {
+      val cd: ClassDef = if (!md.impl.exists(_.isInstanceOf[TypeDef])) {
         rawCd
       } else {
         val aliasToTypes = md.impl.collect {

--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Factory.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Factory.scala
@@ -95,7 +95,19 @@ object Factory {
       if (!traitType.baseClasses.contains(c.symbolOf[js.Object])) {
         bail("Trait must extends scala.scalajs.js.Object.")
       }
-      val jsNameType = c.typeOf[js.annotation.JSName]
+      val typeArguments = traitType.typeArgs.map { a =>
+        TypeDef(
+          Modifiers(Flag.PARAM),
+          TypeName(a.toString),
+          List.empty,
+          TypeBoundsTree(TypeTree(), TypeTree())
+        )
+      }
+      val typeParams = traitType.typeArgs.map { a =>
+        TypeName(a.toString)
+      }
+      val genericTypeNames = typeParams.map(t => t.toString -> t).toMap
+      val jsNameType       = c.typeOf[js.annotation.JSName]
       def symbolToJSKeyName(s: Symbol): String = {
         val jsName = s.annotations.collectFirst {
           case t if t.tree.tpe == jsNameType =>
@@ -140,7 +152,7 @@ object Factory {
              ..$requiredArgs
            )
            ..$optionalArgs
-           obj$$.asInstanceOf[${md.name.toTypeName}]
+           obj$$.asInstanceOf[${md.name.toTypeName}[..${typeParams}]]
          """
       }
       val arguments = members
@@ -152,10 +164,19 @@ object Factory {
               EmptyTree
             } else {
               val returnType = s.asMethod.returnType
-              if (isDefined) {
-                q"${name}: ${returnType}"
-              } else {
-                ValDef(Modifiers(), name, q"${returnType}", q"scala.scalajs.js.undefined")
+              genericTypeNames.get(returnType.toString) match {
+                case Some(value) =>
+                  if (isDefined) {
+                    q"${name}: ${value}"
+                  } else {
+                    bail("Generics parameter in js.UndefOr[...] is not supported yet")
+                  }
+                case None =>
+                  if (isDefined) {
+                    q"${name}: ${returnType}"
+                  } else {
+                    ValDef(Modifiers(), name, q"${returnType}", q"scala.scalajs.js.undefined")
+                  }
               }
             }
         }
@@ -168,9 +189,9 @@ object Factory {
           noSelfType,
           md.impl.body ++ List(
             q"""
-            def apply(
+            def apply[..${typeArguments}](
               ..$arguments
-            ): ${md.name.toTypeName} = { ..$impl }
+            ): ${md.name.toTypeName}[..${typeParams}] = { ..${impl} }
             """
           )
         )

--- a/macros/src/test/scala/net/exoego/scalajs/types/util/FactoryTest.scala
+++ b/macros/src/test/scala/net/exoego/scalajs/types/util/FactoryTest.scala
@@ -39,6 +39,10 @@ class FactoryTest extends AnyFlatSpec with Matchers {
     """@Factory trait X extends Seq[Int]""" shouldNot compile
   }
 
+  it should "support generic types" in {
+    """val o: GenericTrait[String, Int] = GenericTrait[String, Int](a = "yay", b = 42)""" should compile
+  }
+
   "factory method " should "have defined parameter" in {
     """ val a: Target = Target(name = "yay")
       | """.stripMargin should compile
@@ -140,4 +144,10 @@ trait Inherited extends TargetScalaNative {
   var own: Int
   @JSName("type") var type_ : String
   @JSName("NAMED") var named: js.UndefOr[String] = js.undefined
+}
+
+@Factory
+trait GenericTrait[A, B] extends js.Object {
+  val a: A
+  val b: B
 }


### PR DESCRIPTION
Closes #73

Traits with generic fields are now supported.

```scala
@Factory
trait GenericTrait[A, B] extends js.Object {
  val a: A
  val b: B
}
```

Implementations is very dirty and may not work with some cases, but done is better than perfect...
