### PR TITLE
Macro annotation should use whitebox macro

### DIFF
--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Factory.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Factory.scala
@@ -2,7 +2,7 @@ package net.exoego.scalajs.types.util
 
 import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.language.experimental.macros
-import scala.reflect.macros.blackbox
+import scala.reflect.macros.whitebox
 import scala.scalajs.js
 
 /**
@@ -56,10 +56,10 @@ class Factory(settings: Any*) extends StaticAnnotation {
 }
 
 object Factory {
-  def impl(c: blackbox.Context)(annottees: c.Expr[Any]*) = {
+  def impl(c: whitebox.Context)(annottees: c.Expr[Any]*) = {
     import c.universe._
     import Helper._
-    implicit val context: blackbox.Context = c
+    implicit val context: whitebox.Context = c
 
     annotteeShouldBeTrait(c)(annottees)
 

--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Helper.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Helper.scala
@@ -1,18 +1,18 @@
 package net.exoego.scalajs.types.util
 
-import scala.reflect.macros.blackbox
+import scala.reflect.macros.whitebox
 import scala.scalajs.js
 
 private[util] object Helper {
   private final val libraryNamePrefix: String = "[scalajs-types-util]"
-  def warning(message: String)(implicit c: blackbox.Context): Unit = {
+  def warning(message: String)(implicit c: whitebox.Context): Unit = {
     c.warning(c.enclosingPosition, s"${libraryNamePrefix} ${message}")
   }
-  def bail(message: String)(implicit c: blackbox.Context): Nothing = {
+  def bail(message: String)(implicit c: whitebox.Context): Nothing = {
     c.abort(c.enclosingPosition, s"${libraryNamePrefix} ${message}")
   }
 
-  def annotteeShouldBeTrait(c: blackbox.Context)(annottees: Seq[c.Expr[Any]]): Unit = {
+  def annotteeShouldBeTrait(c: whitebox.Context)(annottees: Seq[c.Expr[Any]]): Unit = {
     import c.universe._
     annottees match {
       case List(Expr(ClassDef(mods, _, _, _))) if mods.hasFlag(Flag.TRAIT) =>
@@ -23,7 +23,7 @@ private[util] object Helper {
     }
   }
 
-  def getInheritedMembers(c: blackbox.Context)(argumentType: c.universe.Type): List[c.universe.Symbol] = {
+  def getInheritedMembers(c: whitebox.Context)(argumentType: c.universe.Type): List[c.universe.Symbol] = {
     import c.universe._
     // maybe decls instead of members?
     (argumentType.members.toSet -- c.typeOf[js.Object].members.toSet).toList
@@ -31,7 +31,7 @@ private[util] object Helper {
       .sortBy(_.name.decodedName.toString)
   }
 
-  def getArgumentType[T]()(implicit c: blackbox.Context): T = {
+  def getArgumentType[T]()(implicit c: whitebox.Context): T = {
     import c.universe._
     val argumentType: c.universe.Type = {
       val macroTypeWithArguments          = c.typecheck(q"${c.prefix.tree}").tpe
@@ -48,7 +48,7 @@ private[util] object Helper {
     argumentType.asInstanceOf[T]
   }
 
-  def isScalaJsNative(c: blackbox.Context)(mods: c.universe.Modifiers): Boolean = {
+  def isScalaJsNative(c: whitebox.Context)(mods: c.universe.Modifiers): Boolean = {
     import c.universe._
     mods.annotations.exists {
       case q"new scala.scalajs.js.native()" => true
@@ -58,7 +58,7 @@ private[util] object Helper {
     }
   }
 
-  def nativeIfNeeded(c: blackbox.Context)(tree: c.universe.Tree, isJsNative: Boolean): c.universe.Tree = {
+  def nativeIfNeeded(c: whitebox.Context)(tree: c.universe.Tree, isJsNative: Boolean): c.universe.Tree = {
     import c.universe._
     if (isJsNative) {
       tree match {

--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Omit.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Omit.scala
@@ -2,7 +2,7 @@ package net.exoego.scalajs.types.util
 
 import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.language.experimental.macros
-import scala.reflect.macros.blackbox
+import scala.reflect.macros.whitebox
 import scala.scalajs.js
 
 /**
@@ -46,10 +46,10 @@ class Omit[T <: js.Object](keys: String*) extends StaticAnnotation {
 }
 
 object Omit {
-  def impl(c: blackbox.Context)(annottees: c.Expr[Any]*) = {
+  def impl(c: whitebox.Context)(annottees: c.Expr[Any]*) = {
     import c.universe._
     import Helper._
-    implicit val context: blackbox.Context = c
+    implicit val context: whitebox.Context = c
 
     val specifiedFieldNames: Set[String] = c.prefix.tree match {
       case q"new Omit[$a](..$b)" => b.map(_.toString.drop(1).dropRight(1)).toSet

--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Partial.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Partial.scala
@@ -2,7 +2,7 @@ package net.exoego.scalajs.types.util
 
 import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.language.experimental.macros
-import scala.reflect.macros.blackbox
+import scala.reflect.macros.whitebox
 import scala.scalajs.js
 
 /**
@@ -48,7 +48,7 @@ class Partial[T <: js.Object] extends StaticAnnotation {
 }
 
 object Partial {
-  def impl(c: blackbox.Context)(annottees: c.Expr[Any]*) = {
+  def impl(c: whitebox.Context)(annottees: c.Expr[Any]*) = {
     import c.universe._
     import Helper._
     implicit val context = c

--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Pick.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Pick.scala
@@ -2,7 +2,7 @@ package net.exoego.scalajs.types.util
 
 import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.language.experimental.macros
-import scala.reflect.macros.blackbox
+import scala.reflect.macros.whitebox
 import scala.scalajs.js
 
 /**
@@ -46,7 +46,7 @@ class Pick[T <: js.Object](keys: String*) extends StaticAnnotation {
 }
 
 object Pick {
-  def impl(c: blackbox.Context)(annottees: c.Expr[Any]*) = {
+  def impl(c: whitebox.Context)(annottees: c.Expr[Any]*) = {
     import c.universe._
     import Helper._
     implicit val context = c

--- a/macros/src/main/scala/net/exoego/scalajs/types/util/ReadOnly.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/ReadOnly.scala
@@ -2,7 +2,7 @@ package net.exoego.scalajs.types.util
 
 import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.language.experimental.macros
-import scala.reflect.macros.blackbox
+import scala.reflect.macros.whitebox
 import scala.scalajs.js
 
 /**
@@ -51,7 +51,7 @@ class ReadOnly[T <: js.Object] extends StaticAnnotation {
 }
 
 object ReadOnly {
-  def impl(c: blackbox.Context)(annottees: c.Expr[Any]*) = {
+  def impl(c: whitebox.Context)(annottees: c.Expr[Any]*) = {
     import c.universe._
     import Helper._
     implicit val context = c

--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Record.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Record.scala
@@ -2,7 +2,7 @@ package net.exoego.scalajs.types.util
 
 import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.language.experimental.macros
-import scala.reflect.macros.blackbox
+import scala.reflect.macros.whitebox
 import scala.scalajs.js
 
 /**
@@ -44,7 +44,7 @@ class Record[T <: js.Object](keys: String*) extends StaticAnnotation {
 }
 
 object Record {
-  def impl(c: blackbox.Context)(annottees: c.Expr[Any]*) = {
+  def impl(c: whitebox.Context)(annottees: c.Expr[Any]*) = {
     import c.universe._
     import Helper._
     implicit val context = c

--- a/macros/src/main/scala/net/exoego/scalajs/types/util/Required.scala
+++ b/macros/src/main/scala/net/exoego/scalajs/types/util/Required.scala
@@ -2,7 +2,7 @@ package net.exoego.scalajs.types.util
 
 import scala.annotation.{StaticAnnotation, compileTimeOnly}
 import scala.language.experimental.macros
-import scala.reflect.macros.blackbox
+import scala.reflect.macros.whitebox
 import scala.scalajs.js
 import scala.scalajs.js.UndefOr
 
@@ -51,7 +51,7 @@ class Required[T <: js.Object] extends StaticAnnotation {
 }
 
 object Required {
-  def impl(c: blackbox.Context)(annottees: c.Expr[Any]*) = {
+  def impl(c: whitebox.Context)(annottees: c.Expr[Any]*) = {
     import c.universe._
     import Helper._
     implicit val context = c


### PR DESCRIPTION
It seems fine even with blackbox, but changed according to documentation.

> https://docs.scala-lang.org/overviews/macros/annotations.html
> Macro annotations must be whitebox. If you declare a macro annotation as blackbox, it will not work.
